### PR TITLE
Add new examples for schema data-models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+# [1.38.1] - 2023-09-28
+
+### Added
+
+- Added multiple data-models examples
+
 # [1.38.0] - 2023-09-28
 
 - Nanothings - Nanotag

--- a/data-models/ambiance/humidity/schema.json
+++ b/data-models/ambiance/humidity/schema.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/akenza-io/device-type-library/master/data-models/ambiance/humidity/schema.json",
+    "$defs": {
+        "type": "number",
+        "title": "Humidity",
+        "description": "The humidity in percent.",
+        "unit": "%",
+        "multipleOf": 0.1,
+        "maximum": 100.0,
+        "minimum": 0.0
+    }
+  }

--- a/data-models/ambiance/sound/schema.json
+++ b/data-models/ambiance/sound/schema.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$defs": {
+        "$id": "https://raw.githubusercontent.com/akenza-io/device-type-library/master/data-models/ambiance/sound/schema.json",
+        "type": "number",
+        "title": "Sound Average",
+        "description": "Average value of the sound pressure level in decibel.",
+        "unit": "dBA",
+        "multipleOf": 0.1,
+        "maximum": 120.0,
+        "exclusiveMaximum": 120.1,
+        "minimum": 20.0,
+        "exclusiveMinimum": 19.9
+    }
+  }

--- a/data-models/ambiance/temperature/flat/schema.json
+++ b/data-models/ambiance/temperature/flat/schema.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/akenza-io/device-type-library/master/data-models/ambiance/temperature/flat/schema.json",
+    "type": "number",
+    "title": "Temperature Celcius",
+    "description": "The temperature in degree Celsius.",
+    "unit": "°C",
+    "multipleOf": 0.1,
+    "maximum": 100.0,
+    "exclusiveMaximum": 100.1,
+    "minimum": -100.0,
+    "exclusiveMinimum": -100.1
+  }

--- a/data-models/common/battery-level/schema.json
+++ b/data-models/common/battery-level/schema.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://raw.githubusercontent.com/akenza-io/device-type-library/master/data-models/common/battery-level/schema.json",
+    "$defs": {
+        "batteryLevel" : {
+            "type": "number",
+            "title": "Battery Level",
+            "description": "The battery level in percent.",
+            "unit": "%",
+            "multipleOf": 0.1,
+            "maximum": 100.0,
+            "minimum": 0.0
+        }
+    }
+}


### PR DESCRIPTION
This PR adds new examples for schema data-models, which should later be used as Akenza default-values for primitive type validations.