### PR TITLE
Fix high temperature values due to incorrect payload parsing on FPort2

### DIFF
--- a/types/dragino/lht65n/uplink.js
+++ b/types/dragino/lht65n/uplink.js
@@ -93,7 +93,7 @@ function decoder(bytes, port) {
   const pollMessageStatus = (bytes[6] >> 7) & 0x01;
   const connect = (bytes[6] & 0x80) >> 7;
   const decode = { lifecycle: {}, decoded: {}, external: {}, datalog: {} };
-  if (((port === 3) & (bytes[2] === 0x01)) | (bytes[2] === 0x02)) {
+  if (((port === 3) & ((bytes[2] === 0x01) | (bytes[2] === 0x02))) {
     const array1 = [];
     const bytes1 = "0x";
     const str1 = Str1(bytes);


### PR DESCRIPTION
**Problem:**
The decoder incorrectly handles the temperature data from payloads on FPort2 if the second temperature byte is `0x02`. This results in anomalously high and incorrect temperature readings, which are then written to akenzaDB.

**Example of Issue:**
Payload: `"CCB5026C039F010A857FFF"`

**Incorrect Output:**
```
{
  "data": {
    "temperature": [276.51, 407.05, 26.93, 327.67]
  },
  "topic": "default"
}
```

**Expected Output:**
```
{
  "data": {
    "temperature": 6.2,
    "humidity": 92.7
  },
  "topic": "default"
}
```

**Cause:**
The decoder logic in line 96 ff mistakenly routes the processing to the alarming section if the second byte of the temperature data is `0x02`.

**Solution:**
This pull request modifies the decoder logic to properly interpret the temperature data bytes, ensuring that the correct values are extracted and processed. Specifically, it adjusts the condition checks around line 96 to avoid erroneous entry into alarm handling logic when the 0x02 byte is encountered under normal conditions.