### PR TITLE
Disruptive repeat and suppress messages

### DIFF
--- a/types/disruptiveTechnologies/co2/network_status.schema.json
+++ b/types/disruptiveTechnologies/co2/network_status.schema.json
@@ -22,9 +22,23 @@
       "title": "Transmission mode",
       "description": "Transmission mode",
       "type": "string",
-      "enum": ["LOW_POWER_STANDARD_MODE", "HIGH_POWER_BOOST_MODE"],
+      "enum": [
+        "LOW_POWER_STANDARD_MODE",
+        "HIGH_POWER_BOOST_MODE"
+      ],
+      "hideFromKpis": true
+    },
+    "sqi": {
+      "title": "Signal quality index",
+      "description": "Signal quality index",
+      "type": "integer",
       "hideFromKpis": true
     }
   },
-  "required": ["signalStrength", "rssi", "transmissionMode"]
+  "required": [
+    "signalStrength",
+    "rssi",
+    "transmissionMode",
+    "sqi"
+  ]
 }

--- a/types/disruptiveTechnologies/co2/uplink.js
+++ b/types/disruptiveTechnologies/co2/uplink.js
@@ -1,32 +1,35 @@
 function consume(event) {
   const { eventType } = event.data;
   const sample = {};
-  let topic = eventType;
+  const now = new Date().getTime();
+  const state = event.state || {};
 
   if (eventType === "humidity") {
     sample.humidity = event.data.humidity.relativeHumidity;
     sample.temperature = event.data.humidity.temperature;
-    topic = "default";
+    emit("sample", { data: sample, topic: "default" });
   } else if (eventType === "co2") {
-    sample.co2 = event.data.co2.ppm;
+    emit("sample", { data: { co2: event.data.co2.ppm }, topic: "co2" });
   } else if (eventType === "pressure") {
-    sample.pressure = event.data.pressure.pascal;
+    emit("sample", { data: { pressure: event.data.pressure.pascal }, topic: "pressure" });
   } else if (eventType === "networkStatus") {
-    sample.signalStrength = event.data.networkStatus.signalStrength;
-    sample.rssi = event.data.networkStatus.rssi;
-    sample.transmissionMode = event.data.networkStatus.transmissionMode;
-    if (sample.rssi >= -50) {
-      sample.sqi = 3;
-    } else if (sample.rssi < -50 && sample.rssi >= -100) {
-      sample.sqi = 2;
-    } else {
-      sample.sqi = 1;
+    // Supress networkStatus for an hour
+    if (state.lastNetworkEmittedAt === undefined || now - state.lastNetworkEmittedAt >= 3600000) {
+      sample.signalStrength = event.data.networkStatus.signalStrength;
+      sample.rssi = event.data.networkStatus.rssi;
+      sample.transmissionMode = event.data.networkStatus.transmissionMode;
+      if (sample.rssi >= -50) {
+        sample.sqi = 3;
+      } else if (sample.rssi < -50 && sample.rssi >= -100) {
+        sample.sqi = 2;
+      } else {
+        sample.sqi = 1;
+      }
+      state.lastNetworkEmittedAt = now;
+      emit("sample", { data: sample, topic: "network_status" });
+      emit("state", state);
     }
-    topic = "network_status";
   } else if (eventType === "batteryStatus") {
-    sample.batteryLevel = event.data.batteryStatus.percentage;
-    topic = "lifecycle";
+    emit("sample", { data: { batteryLevel: event.data.batteryStatus.percentage }, topic: "lifecycle" });
   }
-
-  emit("sample", { data: sample, topic });
 }

--- a/types/disruptiveTechnologies/contact/network_status.schema.json
+++ b/types/disruptiveTechnologies/contact/network_status.schema.json
@@ -27,11 +27,18 @@
         "HIGH_POWER_BOOST_MODE"
       ],
       "hideFromKpis": true
+    },
+    "sqi": {
+      "title": "Signal quality index",
+      "description": "Signal quality index",
+      "type": "integer",
+      "hideFromKpis": true
     }
   },
   "required": [
     "signalStrength",
     "rssi",
-    "transmissionMode"
+    "transmissionMode",
+    "sqi"
   ]
 }

--- a/types/disruptiveTechnologies/contact/uplink.js
+++ b/types/disruptiveTechnologies/contact/uplink.js
@@ -1,29 +1,41 @@
 function consume(event) {
   const { eventType } = event.data;
   const sample = {};
-  let topic = eventType;
+  const now = new Date().getTime();
+  const state = event.state || {};
 
   if (eventType === "contact") {
-    sample.contact = event.data.contact.state;
-    topic = "contact";
+    state.lastContact = event.data.contact.state;
+    state.lastSampleEmittedAt = now;
+    emit("sample", { data: { contact: state.lastContact }, topic: "contact" });
   } else if (eventType === "touch") {
-    sample.touch = true;
+    emit("sample", { data: { touch: true }, topic: "touch" });
   } else if (eventType === "networkStatus") {
-    sample.signalStrength = event.data.networkStatus.signalStrength;
-    sample.rssi = event.data.networkStatus.rssi;
-    sample.transmissionMode = event.data.networkStatus.transmissionMode;
-    if (sample.rssi >= -50) {
-      sample.sqi = 3;
-    } else if (sample.rssi < -50 && sample.rssi >= -100) {
-      sample.sqi = 2;
-    } else {
-      sample.sqi = 1;
+    // Supress networkStatus for an hour
+    if (state.lastNetworkEmittedAt === undefined || now - state.lastNetworkEmittedAt >= 3600000) {
+      sample.signalStrength = event.data.networkStatus.signalStrength;
+      sample.rssi = event.data.networkStatus.rssi;
+      sample.transmissionMode = event.data.networkStatus.transmissionMode;
+      if (sample.rssi >= -50) {
+        sample.sqi = 3;
+      } else if (sample.rssi < -50 && sample.rssi >= -100) {
+        sample.sqi = 2;
+      } else {
+        sample.sqi = 1;
+      }
+      state.lastNetworkEmittedAt = now;
+      emit("sample", { data: sample, topic: "network_status" });
     }
-    topic = "network_status";
   } else if (eventType === "batteryStatus") {
     sample.batteryLevel = event.data.batteryStatus.percentage;
-    topic = "lifecycle";
+    emit("sample", { data: sample, topic: "lifecycle" });
   }
 
-  emit("sample", { data: sample, topic });
+  // Give out a repeated sample each hour so our charts are keept happy
+  if (now - state.lastSampleEmittedAt >= 3600000) {
+    emit("sample", { data: { contact: state.lastContact }, topic: "contact" });
+    state.lastSampleEmittedAt = now;
+  }
+
+  emit("state", state);
 }

--- a/types/disruptiveTechnologies/contact/uplink.spec.js
+++ b/types/disruptiveTechnologies/contact/uplink.spec.js
@@ -19,6 +19,16 @@ describe("Digital Technologies Contact Sensor Uplink", () => {
       });
   });
 
+  let networkStatusSchema = null;
+  before((done) => {
+    utils
+      .loadSchema(`${__dirname}/network_status.schema.json`)
+      .then((parsedSchema) => {
+        networkStatusSchema = parsedSchema;
+        done();
+      });
+  });
+
   describe("consume()", () => {
     it("should decode the Digital Technologies Contact Sensor payload", () => {
       const data = {
@@ -36,6 +46,7 @@ describe("Digital Technologies Contact Sensor Uplink", () => {
         timestamp: "2021-09-15T14:48:05.948000Z",
         labels: {},
       };
+
       utils.expectEmits((type, value) => {
         assert.equal(type, "sample");
         assert.isNotNull(value);
@@ -47,6 +58,112 @@ describe("Digital Technologies Contact Sensor Uplink", () => {
         utils.validateSchema(value.data, objectPresentSchema, {
           throwError: true,
         });
+      });
+
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "state");
+        assert.isNotNull(value);
+        assert.equal(value.lastContact, "OPEN");
+        // assert.equal(value.lastSampleEmittedAt);
+      });
+
+      consume(data);
+    });
+
+
+    it("should repeat the Digital Technologies Contact Sensor payload", () => {
+      const data = {
+        eventId: "c510f9ag03fligl8tvag",
+        targetName:
+          "projects/c3t7p26j4a2g00de1sng/devices/bjmgj6dp0jt000a5dcug",
+        eventType: "networkStatus",
+        data: {
+          eventType: "networkStatus",
+          "networkStatus": {
+            "signalStrength": 10,
+            "rssi": 10,
+            "transmissionMode": "HIGH_POWER_BOOST_MODE",
+            "updateTime": "2024-12-06T14:23:50.728000Z"
+          }
+        },
+        timestamp: "2021-09-15T14:48:05.948000Z",
+        labels: {},
+        state: {
+          lastContact: "OPEN",
+          lastSampleEmittedAt: 1752131670374
+        }
+      };
+
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "sample");
+        assert.isNotNull(value);
+        assert.typeOf(value.data, "object");
+
+        assert.equal(value.topic, "network_status");
+        assert.equal(value.data.signalStrength, 10);
+        assert.equal(value.data.rssi, 10);
+        assert.equal(value.data.transmissionMode, "HIGH_POWER_BOOST_MODE");
+        assert.equal(value.data.sqi, 3);
+
+        utils.validateSchema(value.data, networkStatusSchema, {
+          throwError: true,
+        });
+      });
+
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "sample");
+        assert.isNotNull(value);
+        assert.typeOf(value.data, "object");
+
+        assert.equal(value.topic, "contact");
+        assert.equal(value.data.contact, "OPEN");
+
+        utils.validateSchema(value.data, objectPresentSchema, {
+          throwError: true,
+        });
+      });
+
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "state");
+        assert.isNotNull(value);
+        assert.equal(value.lastContact, "OPEN");
+        // assert.equal(value.lastSampleEmittedAt);
+        // assert.equal(value.lastNetworkEmittedAt);
+      });
+
+      consume(data);
+    });
+
+    it("should supress the Digital Technologies Contact Sensor network payload", () => {
+      const data = {
+        eventId: "c510f9ag03fligl8tvag",
+        targetName:
+          "projects/c3t7p26j4a2g00de1sng/devices/bjmgj6dp0jt000a5dcug",
+        eventType: "networkStatus",
+        data: {
+          eventType: "networkStatus",
+          "networkStatus": {
+            "signalStrength": 10,
+            "rssi": 10,
+            "transmissionMode": "HIGH_POWER_BOOST_MODE",
+            "updateTime": "2024-12-06T14:23:50.728000Z"
+          }
+        },
+        timestamp: "2021-09-15T14:48:05.948000Z",
+        labels: {},
+        state: {
+          lastContact: "OPEN",
+          lastSampleEmittedAt: new Date().getTime(),
+          lastNetworkEmittedAt: new Date().getTime()
+        }
+      };
+
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "state");
+        assert.isNotNull(value);
+        assert.equal(value.lastContact, "OPEN");
+        // assert.equal(value.lastSampleEmittedAt);
+        // assert.equal(value.lastNetworkEmittedAt);
       });
 
       consume(data);

--- a/types/disruptiveTechnologies/desk/network_status.schema.json
+++ b/types/disruptiveTechnologies/desk/network_status.schema.json
@@ -27,6 +27,12 @@
         "HIGH_POWER_BOOST_MODE"
       ],
       "hideFromKpis": true
+    },
+    "sqi": {
+      "title": "Signal quality index",
+      "description": "Signal quality index",
+      "type": "integer",
+      "hideFromKpis": true
     }
   },
   "required": [

--- a/types/disruptiveTechnologies/desk/uplink.spec.js
+++ b/types/disruptiveTechnologies/desk/uplink.spec.js
@@ -37,11 +37,6 @@ describe("Digital Technologies Desk Sensor Uplink", () => {
       };
 
       utils.expectEmits((type, value) => {
-        assert.equal(type, "state");
-        assert.equal(value.lastOccupiedValue, false);
-      });
-
-      utils.expectEmits((type, value) => {
         assert.equal(type, "sample");
         assert.isNotNull(value);
         assert.typeOf(value.data, "object");
@@ -52,6 +47,12 @@ describe("Digital Technologies Desk Sensor Uplink", () => {
         assert.equal(value.data.minutesSinceLastOccupied, 0);
 
         utils.validateSchema(value.data, occupancySchema, { throwError: true });
+      });
+
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "state");
+        assert.equal(value.lastOccupiedValue, false);
+        // assert.equal(value.lastSampleEmittedAt);
       });
 
       consume(data);
@@ -76,9 +77,50 @@ describe("Digital Technologies Desk Sensor Uplink", () => {
       };
 
       utils.expectEmits((type, value) => {
+        assert.equal(type, "sample");
+        assert.isNotNull(value);
+        assert.typeOf(value.data, "object");
+
+        assert.equal(value.topic, "occupancy");
+        assert.equal(value.data.occupied, true);
+        assert.equal(value.data.occupancy, 2);
+        assert.equal(value.data.minutesSinceLastOccupied, 0);
+
+        utils.validateSchema(value.data, occupancySchema, { throwError: true });
+      });
+
+      utils.expectEmits((type, value) => {
         assert.equal(type, "state");
         assert.equal(value.lastOccupiedValue, true);
+        // assert.equal(value.lastSampleEmittedAt);
       });
+
+      consume(data);
+    });
+
+    it("should repeat the Digital Technologies Contact Sensor payload", () => {
+      const data = {
+        eventId: "c510f9ag03fligl8tvag",
+        targetName:
+          "projects/c3t7p26j4a2g00de1sng/devices/bjmgj6dp0jt000a5dcug",
+        eventType: "networkStatus",
+        data: {
+          eventType: "networkStatus",
+          "networkStatus": {
+            "signalStrength": 10,
+            "rssi": 10,
+            "transmissionMode": "HIGH_POWER_BOOST_MODE",
+            "updateTime": "2024-12-06T14:23:50.728000Z"
+          }
+        },
+        timestamp: "2021-09-15T14:48:05.948000Z",
+        labels: {},
+        state: {
+          lastOccupiedValue: true,
+          lastNetworkEmittedAt: new Date().getTime(),
+          lastSampleEmittedAt: 1752131670374
+        }
+      };
 
       utils.expectEmits((type, value) => {
         assert.equal(type, "sample");
@@ -91,6 +133,14 @@ describe("Digital Technologies Desk Sensor Uplink", () => {
         assert.equal(value.data.minutesSinceLastOccupied, 0);
 
         utils.validateSchema(value.data, occupancySchema, { throwError: true });
+      });
+
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "state");
+        assert.isNotNull(value);
+        assert.equal(value.lastOccupiedValue, true);
+        // assert.equal(value.lastSampleEmittedAt);
+        // assert.equal(value.lastNetworkEmittedAt);
       });
 
       consume(data);

--- a/types/disruptiveTechnologies/humidity/network_status.schema.json
+++ b/types/disruptiveTechnologies/humidity/network_status.schema.json
@@ -22,9 +22,22 @@
       "title": "Transmission mode",
       "description": "Transmission mode",
       "type": "string",
-      "enum": ["LOW_POWER_STANDARD_MODE", "HIGH_POWER_BOOST_MODE"],
+      "enum": [
+        "LOW_POWER_STANDARD_MODE",
+        "HIGH_POWER_BOOST_MODE"
+      ],
+      "hideFromKpis": true
+    },
+    "sqi": {
+      "title": "Signal quality index",
+      "description": "Signal quality index",
+      "type": "integer",
       "hideFromKpis": true
     }
   },
-  "required": ["signalStrength", "rssi", "transmissionMode"]
+  "required": [
+    "signalStrength",
+    "rssi",
+    "transmissionMode"
+  ]
 }

--- a/types/disruptiveTechnologies/humidity/uplink.js
+++ b/types/disruptiveTechnologies/humidity/uplink.js
@@ -1,6 +1,8 @@
 function consume(event) {
   const { eventType } = event.data;
   const sample = {};
+  const now = new Date().getTime();
+  const state = event.state || {};
 
   if (eventType === "humidity") {
     // New version
@@ -19,17 +21,22 @@ function consume(event) {
     sample.touch = true;
     emit("sample", { data: sample, topic: "touch" });
   } else if (eventType === "networkStatus") {
-    sample.signalStrength = event.data.networkStatus.signalStrength;
-    sample.rssi = event.data.networkStatus.rssi;
-    sample.transmissionMode = event.data.networkStatus.transmissionMode;
-    if (sample.rssi >= -50) {
-      sample.sqi = 3;
-    } else if (sample.rssi < -50 && sample.rssi >= -100) {
-      sample.sqi = 2;
-    } else {
-      sample.sqi = 1;
+    // Supress networkStatus for an hour
+    if (state.lastNetworkEmittedAt === undefined || now - state.lastNetworkEmittedAt >= 3600000) {
+      sample.signalStrength = event.data.networkStatus.signalStrength;
+      sample.rssi = event.data.networkStatus.rssi;
+      sample.transmissionMode = event.data.networkStatus.transmissionMode;
+      if (sample.rssi >= -50) {
+        sample.sqi = 3;
+      } else if (sample.rssi < -50 && sample.rssi >= -100) {
+        sample.sqi = 2;
+      } else {
+        sample.sqi = 1;
+      }
+      state.lastNetworkEmittedAt = now;
+      emit("sample", { data: sample, topic: "network_status" });
+      emit("state", state);
     }
-    emit("sample", { data: sample, topic: "network_status" });
   } else if (eventType === "batteryStatus") {
     sample.batteryLevel = event.data.batteryStatus.percentage;
     emit("sample", { data: sample, topic: "lifecycle" });

--- a/types/disruptiveTechnologies/motion/network_status.schema.json
+++ b/types/disruptiveTechnologies/motion/network_status.schema.json
@@ -22,9 +22,22 @@
       "title": "Transmission mode",
       "description": "Transmission mode",
       "type": "string",
-      "enum": ["LOW_POWER_STANDARD_MODE", "HIGH_POWER_BOOST_MODE"],
+      "enum": [
+        "LOW_POWER_STANDARD_MODE",
+        "HIGH_POWER_BOOST_MODE"
+      ],
+      "hideFromKpis": true
+    },
+    "sqi": {
+      "title": "Signal quality index",
+      "description": "Signal quality index",
+      "type": "integer",
       "hideFromKpis": true
     }
   },
-  "required": ["signalStrength", "rssi", "transmissionMode"]
+  "required": [
+    "signalStrength",
+    "rssi",
+    "transmissionMode"
+  ]
 }

--- a/types/disruptiveTechnologies/motion/uplink.js
+++ b/types/disruptiveTechnologies/motion/uplink.js
@@ -1,7 +1,8 @@
 function consume(event) {
   const { eventType } = event.data;
   const sample = {};
-  let topic = eventType;
+  const now = new Date().getTime();
+  const state = event.state || {};
 
   if (eventType === "motion") {
     const motion = event.data.motion.state;
@@ -10,23 +11,35 @@ function consume(event) {
     } else {
       sample.motion = false;
     }
-    topic = "motion";
+    state.lastMotion = sample.motion;
+    state.lastSampleEmittedAt = now;
+    emit("sample", { data: sample, topic: "motion" });
   } else if (eventType === "networkStatus") {
-    sample.signalStrength = event.data.networkStatus.signalStrength;
-    sample.rssi = event.data.networkStatus.rssi;
-    sample.transmissionMode = event.data.networkStatus.transmissionMode;
-    if (sample.rssi >= -50) {
-      sample.sqi = 3;
-    } else if (sample.rssi < -50 && sample.rssi >= -100) {
-      sample.sqi = 2;
-    } else {
-      sample.sqi = 1;
+    // Supress networkStatus for an hour
+    if (state.lastNetworkEmittedAt === undefined || now - state.lastNetworkEmittedAt >= 3600000) {
+      sample.signalStrength = event.data.networkStatus.signalStrength;
+      sample.rssi = event.data.networkStatus.rssi;
+      sample.transmissionMode = event.data.networkStatus.transmissionMode;
+      if (sample.rssi >= -50) {
+        sample.sqi = 3;
+      } else if (sample.rssi < -50 && sample.rssi >= -100) {
+        sample.sqi = 2;
+      } else {
+        sample.sqi = 1;
+      }
+      state.lastNetworkEmittedAt = now;
+      emit("sample", { data: sample, topic: "network_status" });
     }
-    topic = "network_status";
   } else if (eventType === "batteryStatus") {
     sample.batteryLevel = event.data.batteryStatus.percentage;
-    topic = "lifecycle";
+    emit("sample", { data: sample, topic: "lifecycle" });
   }
 
-  emit("sample", { data: sample, topic });
+  // Give out a repeated sample each hour so our charts are keept happy
+  if (now - state.lastSampleEmittedAt >= 3600000) {
+    emit("sample", { data: { motion: state.lastMotion }, topic: "motion" });
+    state.lastSampleEmittedAt = now;
+  }
+
+  emit("state", state);
 }

--- a/types/disruptiveTechnologies/motion/uplink.spec.js
+++ b/types/disruptiveTechnologies/motion/uplink.spec.js
@@ -44,6 +44,14 @@ describe("Digital Technologies Proximity Sensor Uplink", () => {
         utils.validateSchema(value.data, motionSchema, { throwError: true });
       });
 
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "state");
+        assert.isNotNull(value);
+
+        assert.equal(value.lastMotion, true);
+        // assert.equal(value.lastSampleEmittedAt);
+      });
+
       consume(data);
     });
   });

--- a/types/disruptiveTechnologies/proximity/network_status.schema.json
+++ b/types/disruptiveTechnologies/proximity/network_status.schema.json
@@ -22,9 +22,22 @@
       "title": "Transmission mode",
       "description": "Transmission mode",
       "type": "string",
-      "enum": ["LOW_POWER_STANDARD_MODE", "HIGH_POWER_BOOST_MODE"],
+      "enum": [
+        "LOW_POWER_STANDARD_MODE",
+        "HIGH_POWER_BOOST_MODE"
+      ],
+      "hideFromKpis": true
+    },
+    "sqi": {
+      "title": "Signal quality index",
+      "description": "Signal quality index",
+      "type": "integer",
       "hideFromKpis": true
     }
   },
-  "required": ["signalStrength", "rssi", "transmissionMode"]
+  "required": [
+    "signalStrength",
+    "rssi",
+    "transmissionMode"
+  ]
 }

--- a/types/disruptiveTechnologies/proximity/uplink.js
+++ b/types/disruptiveTechnologies/proximity/uplink.js
@@ -1,10 +1,10 @@
 function consume(event) {
   const { eventType } = event.data;
-  const sample = {};
-  let topic = eventType;
+  let sample = {};
+  const now = new Date().getTime();
+  const state = event.state || {};
 
   if (eventType === "objectPresent") {
-    topic = "object_present";
     sample.objectPresent = event.data.objectPresent.state;
     if (sample.objectPresent === "PRESENT") {
       sample.proximity = true;
@@ -15,8 +15,6 @@ function consume(event) {
     }
 
     // State manipulation to get a count for object present changes
-    const state = event.state || {};
-
     // Init absolute count
     if (state.count === undefined || state.count === null) {
       state.count = 0;
@@ -32,26 +30,48 @@ function consume(event) {
 
     state.lastStatus = sample.objectPresent;
     sample.count = state.count;
+    state.lastSampleEmittedAt = now;
 
-    emit("state", state);
+    emit("sample", { data: sample, topic: "object_present" });
   } else if (eventType === "touch") {
     sample.touch = true;
+    emit("sample", { data: sample, topic: "touch" });
   } else if (eventType === "networkStatus") {
-    sample.signalStrength = event.data.networkStatus.signalStrength;
-    sample.rssi = event.data.networkStatus.rssi;
-    sample.transmissionMode = event.data.networkStatus.transmissionMode;
-    if (sample.rssi >= -50) {
-      sample.sqi = 3;
-    } else if (sample.rssi < -50 && sample.rssi >= -100) {
-      sample.sqi = 2;
-    } else {
-      sample.sqi = 1;
+    // Supress networkStatus for an hour
+    if (state.lastNetworkEmittedAt === undefined || now - state.lastNetworkEmittedAt >= 3600000) {
+      sample.signalStrength = event.data.networkStatus.signalStrength;
+      sample.rssi = event.data.networkStatus.rssi;
+      sample.transmissionMode = event.data.networkStatus.transmissionMode;
+      if (sample.rssi >= -50) {
+        sample.sqi = 3;
+      } else if (sample.rssi < -50 && sample.rssi >= -100) {
+        sample.sqi = 2;
+      } else {
+        sample.sqi = 1;
+      }
+      state.lastNetworkEmittedAt = now;
+      emit("sample", { data: sample, topic: "network_status" });
     }
-    topic = "network_status";
   } else if (eventType === "batteryStatus") {
     sample.batteryLevel = event.data.batteryStatus.percentage;
-    topic = "lifecycle";
+    emit("sample", { data: sample, topic: "lifecycle" });
   }
 
-  emit("sample", { data: sample, topic });
+  // Give out a repeated sample each hour so our charts are keept happy
+  if (now - state.lastSampleEmittedAt >= 3600000) {
+    sample = {};
+    sample.objectPresent = state.lastStatus;
+    sample.relativeCount = 0;
+    sample.count = state.count;
+    if (sample.objectPresent === "PRESENT") {
+      sample.proximity = true;
+    } else {
+      sample.proximity = false;
+    }
+
+    emit("sample", { data: sample, topic: "object_present" });
+    state.lastSampleEmittedAt = now;
+  }
+
+  emit("state", state);
 }

--- a/types/disruptiveTechnologies/proximity/uplink.spec.js
+++ b/types/disruptiveTechnologies/proximity/uplink.spec.js
@@ -19,6 +19,16 @@ describe("Digital Technologies Proximity Sensor Uplink", () => {
       });
   });
 
+  let touchSchema = null;
+  before((done) => {
+    utils
+      .loadSchema(`${__dirname}/touch.schema.json`)
+      .then((parsedSchema) => {
+        touchSchema = parsedSchema;
+        done();
+      });
+  });
+
   describe("consume()", () => {
     it("should decode the Digital Technologies Proximity Sensor payload and init state", () => {
       const data = {
@@ -38,14 +48,6 @@ describe("Digital Technologies Proximity Sensor Uplink", () => {
       };
 
       utils.expectEmits((type, value) => {
-        assert.equal(type, "state");
-        assert.isNotNull(value);
-
-        assert.equal(value.count, 0);
-        assert.equal(value.lastStatus, "NOT_PRESENT");
-      });
-
-      utils.expectEmits((type, value) => {
         assert.equal(type, "sample");
         assert.isNotNull(value);
         assert.typeOf(value.data, "object");
@@ -59,6 +61,15 @@ describe("Digital Technologies Proximity Sensor Uplink", () => {
         utils.validateSchema(value.data, objectPresentSchema, {
           throwError: true,
         });
+      });
+
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "state");
+        assert.isNotNull(value);
+
+        assert.equal(value.count, 0);
+        assert.equal(value.lastStatus, "NOT_PRESENT");
+        // assert.equal(value.lastSampleEmittedAt);
       });
 
       consume(data);
@@ -81,17 +92,10 @@ describe("Digital Technologies Proximity Sensor Uplink", () => {
         labels: {},
         state: {
           count: 0,
-          lastStatus: "NOT_PRESENT"
+          lastStatus: "NOT_PRESENT",
+          lastSampleEmittedAt: new Date().getTime()
         }
       };
-
-      utils.expectEmits((type, value) => {
-        assert.equal(type, "state");
-        assert.isNotNull(value);
-
-        assert.equal(value.count, 1);
-        assert.equal(value.lastStatus, "PRESENT");
-      });
 
       utils.expectEmits((type, value) => {
         assert.equal(type, "sample");
@@ -107,6 +111,75 @@ describe("Digital Technologies Proximity Sensor Uplink", () => {
         utils.validateSchema(value.data, objectPresentSchema, {
           throwError: true,
         });
+      });
+
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "state");
+        assert.isNotNull(value);
+
+        assert.equal(value.count, 1);
+        assert.equal(value.lastStatus, "PRESENT");
+        // assert.equal(value.lastSampleEmittedAt);
+      });
+
+      consume(data);
+    });
+
+    it("Repeat sample", () => {
+      const data = {
+        eventId: "c510f9ag03fligl8tvag",
+        targetName:
+          "projects/c3t7p26j4a2g00de1sng/devices/bjmgj6dp0jt000a5dcug",
+        eventType: "touch",
+        data: {
+          eventType: "touch",
+          touch: true
+        },
+        timestamp: "2021-09-15T14:48:05.948000Z",
+        labels: {},
+        state: {
+          count: 1,
+          lastStatus: "PRESENT",
+          lastSampleEmittedAt: new Date().getTime() - 3600000
+        }
+      };
+
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "sample");
+        assert.isNotNull(value);
+        assert.typeOf(value.data, "object");
+
+        assert.equal(value.topic, "touch");
+        assert.equal(value.data.touch, true);
+
+        utils.validateSchema(value.data, touchSchema, {
+          throwError: true,
+        });
+      });
+
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "sample");
+        assert.isNotNull(value);
+        assert.typeOf(value.data, "object");
+
+        assert.equal(value.topic, "object_present");
+        assert.equal(value.data.objectPresent, "PRESENT");
+        assert.equal(value.data.proximity, true);
+        assert.equal(value.data.count, 1);
+        assert.equal(value.data.relativeCount, 0); // Should stay 0 as this is not a real sample
+
+        utils.validateSchema(value.data, objectPresentSchema, {
+          throwError: true,
+        });
+      });
+
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "state");
+        assert.isNotNull(value);
+
+        assert.equal(value.count, 1);
+        assert.equal(value.lastStatus, "PRESENT");
+        // assert.equal(value.lastSampleEmittedAt);
       });
 
       consume(data);

--- a/types/disruptiveTechnologies/proximityCounter/network_status.schema.json
+++ b/types/disruptiveTechnologies/proximityCounter/network_status.schema.json
@@ -22,9 +22,22 @@
       "title": "Transmission mode",
       "description": "Transmission mode",
       "type": "string",
-      "enum": ["LOW_POWER_STANDARD_MODE", "HIGH_POWER_BOOST_MODE"],
+      "enum": [
+        "LOW_POWER_STANDARD_MODE",
+        "HIGH_POWER_BOOST_MODE"
+      ],
+      "hideFromKpis": true
+    },
+    "sqi": {
+      "title": "Signal quality index",
+      "description": "Signal quality index",
+      "type": "integer",
       "hideFromKpis": true
     }
   },
-  "required": ["signalStrength", "rssi", "transmissionMode"]
+  "required": [
+    "signalStrength",
+    "rssi",
+    "transmissionMode"
+  ]
 }

--- a/types/disruptiveTechnologies/proximityCounter/uplink.js
+++ b/types/disruptiveTechnologies/proximityCounter/uplink.js
@@ -15,39 +15,49 @@ function calculateIncrement(lastValue, currentValue) {
 function consume(event) {
   const { eventType } = event.data;
   const sample = {};
-  let topic = eventType;
+  const now = new Date().getTime();
+  const state = event.state || {};
 
   if (eventType === "objectPresentCount") {
     sample.objectPresentCount = event.data.objectPresentCount.total;
-    topic = "object_present_count";
-
-    const state = event.state || {};
     // Calculate increment
     sample.relativeCount = calculateIncrement(
       state.lastCount,
       sample.objectPresentCount,
     );
     state.lastCount = sample.objectPresentCount;
+    state.lastSampleEmittedAt = now;
 
-    emit("state", state);
+    emit("sample", { data: sample, topic: "object_present_count" });
   } else if (eventType === "touch") {
     sample.touch = true;
+    emit("sample", { data: sample, topic: "touch" });
   } else if (eventType === "networkStatus") {
-    sample.signalStrength = event.data.networkStatus.signalStrength;
-    sample.rssi = event.data.networkStatus.rssi;
-    sample.transmissionMode = event.data.networkStatus.transmissionMode;
-    if (sample.rssi >= -50) {
-      sample.sqi = 3;
-    } else if (sample.rssi < -50 && sample.rssi >= -100) {
-      sample.sqi = 2;
-    } else {
-      sample.sqi = 1;
+    // Supress networkStatus for an hour
+    if (state.lastNetworkEmittedAt === undefined || now - state.lastNetworkEmittedAt >= 3600000) {
+      sample.signalStrength = event.data.networkStatus.signalStrength;
+      sample.rssi = event.data.networkStatus.rssi;
+      sample.transmissionMode = event.data.networkStatus.transmissionMode;
+      if (sample.rssi >= -50) {
+        sample.sqi = 3;
+      } else if (sample.rssi < -50 && sample.rssi >= -100) {
+        sample.sqi = 2;
+      } else {
+        sample.sqi = 1;
+      }
+      state.lastNetworkEmittedAt = now;
+      emit("sample", { data: sample, topic: "network_status" });
     }
-    topic = "network_status";
   } else if (eventType === "batteryStatus") {
     sample.batteryLevel = event.data.batteryStatus.percentage;
-    topic = "lifecycle";
+    emit("sample", { data: sample, topic: "lifecycle" });
   }
 
-  emit("sample", { data: sample, topic });
+  // Give out a repeated sample each hour so our charts are keept happy
+  if (now - state.lastSampleEmittedAt >= 3600000) {
+    emit("sample", { data: { "objectPresentCount": state.lastCount, "relativeCount": 0 }, topic: "object_present_count" });
+    state.lastSampleEmittedAt = now;
+  }
+
+  emit("state", state);
 }

--- a/types/disruptiveTechnologies/proximityCounter/uplink.spec.js
+++ b/types/disruptiveTechnologies/proximityCounter/uplink.spec.js
@@ -37,13 +37,6 @@ describe("Digital Technologies Proximity Counter Sensor Uplink", () => {
         labels: {},
       };
 
-
-      utils.expectEmits((type, value) => {
-        assert.equal(type, "state");
-        assert.isNotNull(value);
-        assert.equal(value.lastCount, 4176);
-      });
-
       utils.expectEmits((type, value) => {
         assert.equal(type, "sample");
         assert.isNotNull(value);
@@ -56,6 +49,14 @@ describe("Digital Technologies Proximity Counter Sensor Uplink", () => {
         utils.validateSchema(value.data, objectPresentSchema, {
           throwError: true,
         });
+      });
+
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "state");
+        assert.isNotNull(value);
+
+        assert.equal(value.lastCount, 4176);
+        // assert.equal(value.lastSampleEmittedAt);
       });
 
       consume(data);

--- a/types/disruptiveTechnologies/temperature/network_status.schema.json
+++ b/types/disruptiveTechnologies/temperature/network_status.schema.json
@@ -22,9 +22,22 @@
       "title": "Transmission mode",
       "description": "Transmission mode",
       "type": "string",
-      "enum": ["LOW_POWER_STANDARD_MODE", "HIGH_POWER_BOOST_MODE"],
+      "enum": [
+        "LOW_POWER_STANDARD_MODE",
+        "HIGH_POWER_BOOST_MODE"
+      ],
+      "hideFromKpis": true
+    },
+    "sqi": {
+      "title": "Signal quality index",
+      "description": "Signal quality index",
+      "type": "integer",
       "hideFromKpis": true
     }
   },
-  "required": ["signalStrength", "rssi", "transmissionMode"]
+  "required": [
+    "signalStrength",
+    "rssi",
+    "transmissionMode"
+  ]
 }

--- a/types/disruptiveTechnologies/temperature/uplink.js
+++ b/types/disruptiveTechnologies/temperature/uplink.js
@@ -1,6 +1,8 @@
 function consume(event) {
   const { eventType } = event.data;
   const sample = {};
+  const now = new Date().getTime();
+  const state = event.state || {};
 
   if (eventType === "temperature") {
     event.data.temperature.samples.forEach(singleSample => {
@@ -10,17 +12,22 @@ function consume(event) {
     sample.touch = true;
     emit("sample", { data: sample, topic: "touch" });
   } else if (eventType === "networkStatus") {
-    sample.signalStrength = event.data.networkStatus.signalStrength;
-    sample.rssi = event.data.networkStatus.rssi;
-    sample.transmissionMode = event.data.networkStatus.transmissionMode;
-    if (sample.rssi >= -50) {
-      sample.sqi = 3;
-    } else if (sample.rssi < -50 && sample.rssi >= -100) {
-      sample.sqi = 2;
-    } else {
-      sample.sqi = 1;
+    // Supress networkStatus for an hour
+    if (state.lastNetworkEmittedAt === undefined || now - state.lastNetworkEmittedAt >= 3600000) {
+      sample.signalStrength = event.data.networkStatus.signalStrength;
+      sample.rssi = event.data.networkStatus.rssi;
+      sample.transmissionMode = event.data.networkStatus.transmissionMode;
+      if (sample.rssi >= -50) {
+        sample.sqi = 3;
+      } else if (sample.rssi < -50 && sample.rssi >= -100) {
+        sample.sqi = 2;
+      } else {
+        sample.sqi = 1;
+      }
+      state.lastNetworkEmittedAt = now;
+      emit("sample", { data: sample, topic: "network_status" });
+      emit("state", state);
     }
-    emit("sample", { data: sample, topic: "network_status" });
   } else if (eventType === "batteryStatus") {
     sample.batteryLevel = event.data.batteryStatus.percentage;
     emit("sample", { data: sample, topic: "lifecycle" });

--- a/types/disruptiveTechnologies/touch/network_status.schema.json
+++ b/types/disruptiveTechnologies/touch/network_status.schema.json
@@ -22,9 +22,22 @@
       "title": "Transmission mode",
       "description": "Transmission mode",
       "type": "string",
-      "enum": ["LOW_POWER_STANDARD_MODE", "HIGH_POWER_BOOST_MODE"],
+      "enum": [
+        "LOW_POWER_STANDARD_MODE",
+        "HIGH_POWER_BOOST_MODE"
+      ],
+      "hideFromKpis": true
+    },
+    "sqi": {
+      "title": "Signal quality index",
+      "description": "Signal quality index",
+      "type": "integer",
       "hideFromKpis": true
     }
   },
-  "required": ["signalStrength", "rssi", "transmissionMode"]
+  "required": [
+    "signalStrength",
+    "rssi",
+    "transmissionMode"
+  ]
 }

--- a/types/disruptiveTechnologies/touch/uplink.js
+++ b/types/disruptiveTechnologies/touch/uplink.js
@@ -1,26 +1,31 @@
 function consume(event) {
   const { eventType } = event.data;
   const sample = {};
-  let topic = eventType;
+  const now = new Date().getTime();
+  const state = event.state || {};
 
   if (eventType === "touch") {
     sample.touch = true;
+    emit("sample", { data: sample, topic: "touch" });
   } else if (eventType === "networkStatus") {
-    sample.signalStrength = event.data.networkStatus.signalStrength;
-    sample.rssi = event.data.networkStatus.rssi;
-    sample.transmissionMode = event.data.networkStatus.transmissionMode;
-    if (sample.rssi >= -50) {
-      sample.sqi = 3;
-    } else if (sample.rssi < -50 && sample.rssi >= -100) {
-      sample.sqi = 2;
-    } else {
-      sample.sqi = 1;
+    // Supress networkStatus for an hour
+    if (state.lastNetworkEmittedAt === undefined || now - state.lastNetworkEmittedAt >= 3600000) {
+      sample.signalStrength = event.data.networkStatus.signalStrength;
+      sample.rssi = event.data.networkStatus.rssi;
+      sample.transmissionMode = event.data.networkStatus.transmissionMode;
+      if (sample.rssi >= -50) {
+        sample.sqi = 3;
+      } else if (sample.rssi < -50 && sample.rssi >= -100) {
+        sample.sqi = 2;
+      } else {
+        sample.sqi = 1;
+      }
+      state.lastNetworkEmittedAt = now;
+      emit("sample", { data: sample, topic: "network_status" });
+      emit("state", state);
     }
-    topic = "network_status";
   } else if (eventType === "batteryStatus") {
     sample.batteryLevel = event.data.batteryStatus.percentage;
-    topic = "lifecycle";
+    emit("sample", { data: sample, topic: "lifecycle" });
   }
-
-  emit("sample", { data: sample, topic });
 }

--- a/types/disruptiveTechnologies/touchCounter/network_status.schema.json
+++ b/types/disruptiveTechnologies/touchCounter/network_status.schema.json
@@ -22,9 +22,22 @@
       "title": "Transmission mode",
       "description": "Transmission mode",
       "type": "string",
-      "enum": ["LOW_POWER_STANDARD_MODE", "HIGH_POWER_BOOST_MODE"],
+      "enum": [
+        "LOW_POWER_STANDARD_MODE",
+        "HIGH_POWER_BOOST_MODE"
+      ],
+      "hideFromKpis": true
+    },
+    "sqi": {
+      "title": "Signal quality index",
+      "description": "Signal quality index",
+      "type": "integer",
       "hideFromKpis": true
     }
   },
-  "required": ["signalStrength", "rssi", "transmissionMode"]
+  "required": [
+    "signalStrength",
+    "rssi",
+    "transmissionMode"
+  ]
 }

--- a/types/disruptiveTechnologies/touchCounter/uplink.js
+++ b/types/disruptiveTechnologies/touchCounter/uplink.js
@@ -1,29 +1,34 @@
 function consume(event) {
   const { eventType } = event.data;
   const sample = {};
-  let topic = eventType;
+  const now = new Date().getTime();
+  const state = event.state || {};
 
   if (eventType === "touchCount") {
     sample.touchCount = event.data.touchCount.total;
-    topic = "touch_count";
+    emit("sample", { data: sample, topic: "touch_count" })
   } else if (eventType === "touch") {
     sample.touch = true;
+    emit("sample", { data: sample, topic: "touch" })
   } else if (eventType === "networkStatus") {
-    sample.signalStrength = event.data.networkStatus.signalStrength;
-    sample.rssi = event.data.networkStatus.rssi;
-    sample.transmissionMode = event.data.networkStatus.transmissionMode;
-    if (sample.rssi >= -50) {
-      sample.sqi = 3;
-    } else if (sample.rssi < -50 && sample.rssi >= -100) {
-      sample.sqi = 2;
-    } else {
-      sample.sqi = 1;
+    // Supress networkStatus for an hour
+    if (state.lastNetworkEmittedAt === undefined || now - state.lastNetworkEmittedAt >= 3600000) {
+      sample.signalStrength = event.data.networkStatus.signalStrength;
+      sample.rssi = event.data.networkStatus.rssi;
+      sample.transmissionMode = event.data.networkStatus.transmissionMode;
+      if (sample.rssi >= -50) {
+        sample.sqi = 3;
+      } else if (sample.rssi < -50 && sample.rssi >= -100) {
+        sample.sqi = 2;
+      } else {
+        sample.sqi = 1;
+      }
+      state.lastNetworkEmittedAt = now;
+      emit("sample", { data: sample, topic: "network_status" });
+      emit("state", state);
     }
-    topic = "network_status";
   } else if (eventType === "batteryStatus") {
     sample.batteryLevel = event.data.batteryStatus.percentage;
-    topic = "lifecycle";
+    emit("sample", { data: sample, topic: "lifecycle" })
   }
-
-  emit("sample", { data: sample, topic });
 }

--- a/types/disruptiveTechnologies/water/network_status.schema.json
+++ b/types/disruptiveTechnologies/water/network_status.schema.json
@@ -22,9 +22,22 @@
       "title": "Transmission mode",
       "description": "Transmission mode",
       "type": "string",
-      "enum": ["LOW_POWER_STANDARD_MODE", "HIGH_POWER_BOOST_MODE"],
+      "enum": [
+        "LOW_POWER_STANDARD_MODE",
+        "HIGH_POWER_BOOST_MODE"
+      ],
+      "hideFromKpis": true
+    },
+    "sqi": {
+      "title": "Signal quality index",
+      "description": "Signal quality index",
+      "type": "integer",
       "hideFromKpis": true
     }
   },
-  "required": ["signalStrength", "rssi", "transmissionMode"]
+  "required": [
+    "signalStrength",
+    "rssi",
+    "transmissionMode"
+  ]
 }

--- a/types/disruptiveTechnologies/water/uplink.js
+++ b/types/disruptiveTechnologies/water/uplink.js
@@ -1,29 +1,41 @@
 function consume(event) {
   const { eventType } = event.data;
   const sample = {};
-  let topic = eventType;
+  const now = new Date().getTime();
+  const state = event.state || {};
 
   if (eventType === "waterPresent") {
-    sample.waterPresent = event.data.waterPresent.state;
-    topic = "water_present";
+    state.lastWaterPresent = event.data.waterPresent.state;
+    state.lastSampleEmittedAt = now;
+    emit("sample", { data: { waterPresent: state.lastWaterPresent }, topic: "water_present" });
   } else if (eventType === "touch") {
-    sample.touch = true;
+    emit("sample", { data: { touch: true }, topic: "touch" });
   } else if (eventType === "networkStatus") {
-    sample.signalStrength = event.data.networkStatus.signalStrength;
-    sample.rssi = event.data.networkStatus.rssi;
-    sample.transmissionMode = event.data.networkStatus.transmissionMode;
-    if (sample.rssi >= -50) {
-      sample.sqi = 3;
-    } else if (sample.rssi < -50 && sample.rssi >= -100) {
-      sample.sqi = 2;
-    } else {
-      sample.sqi = 1;
+    // Supress networkStatus for an hour
+    if (state.lastNetworkEmittedAt === undefined || now - state.lastNetworkEmittedAt >= 3600000) {
+      sample.signalStrength = event.data.networkStatus.signalStrength;
+      sample.rssi = event.data.networkStatus.rssi;
+      sample.transmissionMode = event.data.networkStatus.transmissionMode;
+      if (sample.rssi >= -50) {
+        sample.sqi = 3;
+      } else if (sample.rssi < -50 && sample.rssi >= -100) {
+        sample.sqi = 2;
+      } else {
+        sample.sqi = 1;
+      }
+      state.lastNetworkEmittedAt = now;
+      emit("sample", { data: sample, topic: "network_status" });
     }
-    topic = "network_status";
   } else if (eventType === "batteryStatus") {
     sample.batteryLevel = event.data.batteryStatus.percentage;
-    topic = "lifecycle";
+    emit("sample", { data: sample, topic: "lifecycle" });
   }
 
-  emit("sample", { data: sample, topic });
+  // Give out a repeated sample each hour so our charts are keept happy
+  if (now - state.lastSampleEmittedAt >= 3600000) {
+    emit("sample", { data: { waterPresent: state.lastWaterPresent }, topic: "water_present" });
+    state.lastSampleEmittedAt = now;
+  }
+
+  emit("state", state);
 }

--- a/types/disruptiveTechnologies/water/uplink.spec.js
+++ b/types/disruptiveTechnologies/water/uplink.spec.js
@@ -36,6 +36,7 @@ describe("Digital Technologies Water Sensor Uplink", () => {
         timestamp: "2021-09-14T08:16:27.517331Z",
         labels: { name: "Temperature Simulator" },
       };
+
       utils.expectEmits((type, value) => {
         assert.equal(type, "sample");
         assert.isNotNull(value);
@@ -47,6 +48,13 @@ describe("Digital Technologies Water Sensor Uplink", () => {
         utils.validateSchema(value.data, waterPresentSchema, {
           throwError: true,
         });
+      });
+
+      utils.expectEmits((type, value) => {
+        assert.equal(type, "state");
+        assert.isNotNull(value);
+        assert.equal(value.lastWaterPresent, "NOT_PRESENT");
+        // assert.equal(value.lastSampleEmittedAt);
       });
 
       consume(data);


### PR DESCRIPTION
Repeating messages only sent once for disruptive devices and suppressing network_state to once an hour