### PR TITLE
Bugfix/schema resolution

### DIFF
--- a/lib/validate-schemas.spec.js
+++ b/lib/validate-schemas.spec.js
@@ -68,12 +68,14 @@ function loadLocalSchema(uri) {
   })
 }
 
+// Walks a JSON Pointer fragment (e.g. "/$defs/temperature/celsius") through a schema object.
 function resolveJsonPointer(schema, pointer) {
   if (!pointer) return schema;
   const parts = pointer.replace(/^\//, "").split("/");
   return parts.reduce((obj, part) => (obj !== undefined ? obj[part] : undefined), schema);
 }
 
+// Loads the base schema file and navigates to the fragment, honouring TEST_MODE.
 async function resolveRef(ref) {
   const hashIndex = ref.indexOf("#");
   const baseUri = hashIndex >= 0 ? ref.slice(0, hashIndex) : ref;
@@ -85,6 +87,12 @@ async function resolveRef(ref) {
   return resolveJsonPointer(schema, fragment);
 }
 
+// Device type schema properties may use $ref alongside sibling keywords (minimum, maximum, …) to
+// override or extend a shared data-model definition. JSON Schema Draft-7 does not support this
+// natively — $ref makes Ajv ignore siblings, causing strictTypes errors. We pre-process the
+// schema here to replicate akenza's own merge behaviour: the remote definition is used as
+// the base and any locally defined keys take precedence, producing a self-contained property
+// object that Ajv can validate without needing to resolve the ref itself.
 async function mergeSchemaRefs(schema) {
   if (!schema.properties) return schema;
 
@@ -92,7 +100,7 @@ async function mergeSchemaRefs(schema) {
     Object.entries(schema.properties).map(async ([key, prop]) => {
       if (!prop.$ref) return [key, prop];
       const resolved = await resolveRef(prop.$ref);
-      const { $ref, ...localOverrides } = prop;
+      const localOverrides = Object.fromEntries(Object.entries(prop).filter(([k]) => k !== "$ref"));
       return [key, { ...resolved, ...localOverrides }];
     }),
   );

--- a/lib/validate-schemas.spec.js
+++ b/lib/validate-schemas.spec.js
@@ -26,7 +26,15 @@ before((done) => {
   });
 });
 
+const remoteSchemaCache = new Map();
+
 function loadRemoteSchema(uri) {
+  if (remoteSchemaCache.has(uri)) {
+    return remoteSchemaCache.get(uri);
+  }
+
+  console.log(`loading schema ${uri}`)
+
   return client
     .get(uri)
     .catch((e) => {
@@ -36,6 +44,8 @@ function loadRemoteSchema(uri) {
       if (res.status >= 400) {
         throw new Error(`Schema loading error: ${res.status} - ${res.statusText}`);
       }
+
+      remoteSchemaCache.set(uri, res.data);
       return res.data;
     })
 }
@@ -56,6 +66,38 @@ function loadLocalSchema(uri) {
       reject(error);
     }
   })
+}
+
+function resolveJsonPointer(schema, pointer) {
+  if (!pointer) return schema;
+  const parts = pointer.replace(/^\//, "").split("/");
+  return parts.reduce((obj, part) => (obj !== undefined ? obj[part] : undefined), schema);
+}
+
+async function resolveRef(ref) {
+  const hashIndex = ref.indexOf("#");
+  const baseUri = hashIndex >= 0 ? ref.slice(0, hashIndex) : ref;
+  const fragment = hashIndex >= 0 ? ref.slice(hashIndex + 1) : "";
+  const schema =
+    process.env.TEST_MODE === "LOCAL"
+      ? await loadLocalSchema(baseUri)
+      : await loadRemoteSchema(baseUri);
+  return resolveJsonPointer(schema, fragment);
+}
+
+async function mergeSchemaRefs(schema) {
+  if (!schema.properties) return schema;
+
+  const entries = await Promise.all(
+    Object.entries(schema.properties).map(async ([key, prop]) => {
+      if (!prop.$ref) return [key, prop];
+      const resolved = await resolveRef(prop.$ref);
+      const { $ref, ...localOverrides } = prop;
+      return [key, { ...resolved, ...localOverrides }];
+    }),
+  );
+
+  return { ...schema, properties: Object.fromEntries(entries) };
 }
 
 const dataKeyTopicRegex = /^[a-zA-Z]([a-zA-Z0-9]+|\.|_)*[a-zA-Z0-9]$/; // Legal in Akenza
@@ -238,13 +280,15 @@ const validateSchema = (filepath) =>
           return;
         }
 
-        ajv.compileAsync(schema)
-          .then(validate => {
+        mergeSchemaRefs(schema)
+          .then((mergedSchema) => ajv.compileAsync(mergedSchema))
+          .then(() => {
             resolve({ isValid: true, filepath });
-          }).catch(err => {
+          })
+          .catch((err) => {
             console.log(err);
             resolve({ isValid: false, filepath, errors: err.errors });
-          })
+          });
       }
     });
   });


### PR DESCRIPTION
Resolves an issue where validating the schemas would produce warnings due to unresolved data-model references

```
strict mode: missing type "number" for keyword "minimum" at "https://akenza.io/elsys/ers-sound/noise.schema.json#/properties/soundPeak" (strictTypes)
```

Closes #451 